### PR TITLE
Add chirp deletion functionality

### DIFF
--- a/internal/database/chirps.sql.go
+++ b/internal/database/chirps.sql.go
@@ -44,6 +44,21 @@ func (q *Queries) DeleteChirp(ctx context.Context) error {
 	return err
 }
 
+const deleteSpecificChirp = `-- name: DeleteSpecificChirp :exec
+DELETE FROM chirps
+WHERE user_id = $1 AND id = $2
+`
+
+type DeleteSpecificChirpParams struct {
+	UserID uuid.NullUUID
+	ID     uuid.UUID
+}
+
+func (q *Queries) DeleteSpecificChirp(ctx context.Context, arg DeleteSpecificChirpParams) error {
+	_, err := q.db.ExecContext(ctx, deleteSpecificChirp, arg.UserID, arg.ID)
+	return err
+}
+
 const readAllChirps = `-- name: ReadAllChirps :many
 SELECT id, created_at, updated_at, body, user_id
 FROM chirps

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ func main() {
 	mux.HandleFunc("GET /admin/metrics", apiCfg.MiddlewareMetricsResult)
 	mux.HandleFunc("GET /api/chirps", apiCfg.ChirpReadHandler)
 	mux.HandleFunc("GET /api/chirps/{chirpID}", apiCfg.ChirpSpecificReadHandler)
+	mux.HandleFunc("DELETE /api/chirps/{chirpID}", apiCfg.ChirpDeleteSpecificHandler)
 	mux.HandleFunc("POST /api/reset", apiCfg.MiddlewareMetricsReset)
 	mux.HandleFunc("POST /api/chirps", apiCfg.ChirpHandler)
 	mux.HandleFunc("POST /api/users", apiCfg.UserHandler)

--- a/sql/queries/chirps.sql
+++ b/sql/queries/chirps.sql
@@ -15,3 +15,7 @@ WHERE id = $1;
 SELECT id, created_at, updated_at, body, user_id
 FROM chirps
 ORDER BY created_at;
+
+-- name: DeleteSpecificChirp :exec
+DELETE FROM chirps
+WHERE user_id = $1 AND id = $2;


### PR DESCRIPTION
- Add DELETE /api/chirps/{chirpID} endpoint
- Implement JWT authentication for chirp deletion
- Add ownership validation to ensure users can only delete their own chirps
- Include proper error handling for not found and forbidden cases